### PR TITLE
update gemspec to a modern version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,49 +1,52 @@
-.idea/
-.rvmrc
-# rcov generated
-coverage
+*.gem
+*.rbc
+.bundle
+.config
+InstalledFiles
+lib/bundler/man
+test/tmp
+test/version_tmp
+tmp
 
-# rdoc generated
-rdoc
+pkg # jeweler generated
 
 # yard generated
-doc
+doc/
 .yardoc
+_yardoc
 
-# bundler
-.bundle
+spec/reports
+coverage # rcov generated
+rdoc # rdoc generated
 
-# jeweler generated
-pkg
+# sqlite3 database
+*.sqlite3
+*.sqlite
 
-ministry_of_state_test
 Gemfile.lock
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
-#
-# * Create a file at ~/.gitignore
-# * Include files you want ignored
-# * Run: git config --global core.excludesfile ~/.gitignore
-#
-# After doing this, these files will be ignored in all your git projects,
-# saving you from having to 'pollute' every project you touch with them
-#
-# Not sure what to needs to be ignored for particular editors/OSes? Here's some ideas to get you started. (Remember, remove the leading # of the line)
-#
+.rvmrc
+.ruby-version
+.ruby-gemset
+.powrc
+
 # For MacOS:
-#
-#.DS_Store
-#
+.DS_Store
+
 # For TextMate
-#*.tmproj
-#tmtags
-#
+*.tmproj
+tmtags
+
 # For emacs:
-#*~
-#\#*
-#.\#*
-#
+*~
+\#*
+.\#*
+
 # For vim:
-#*.swp
+*.swp
+
+# for rubymine IDE
+.idea/
+
 vendor
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,7 @@
 Copyright (c) 2011 Hemant Kumar
 
+MIT License
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including

--- a/README.rdoc
+++ b/README.rdoc
@@ -23,6 +23,20 @@ Because State machines are simple, they do not have to be greater than 2000 line
       end
     end
 
+= Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'ministry_of_state'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem ministry_of_state
+
 == Contributing to ministry_of_state
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,9 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
+
+require "bundler/gem_tasks"
+
 require 'rake'
 
 require 'rake/testtask'
@@ -15,7 +18,6 @@ Rake::TestTask.new(:test) do |test|
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true
 end
-
 
 task :default => :test
 

--- a/lib/ministry_of_state/version.rb
+++ b/lib/ministry_of_state/version.rb
@@ -1,0 +1,3 @@
+module MinistryOfState
+  VERSION = "0.0.1"
+end

--- a/ministry_of_state.gemspec
+++ b/ministry_of_state.gemspec
@@ -1,76 +1,34 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'ministry_of_state/version'
 
-Gem::Specification.new do |s|
-  s.name = %q{ministry_of_state}
-  s.version = "0.0.1"
+Gem::Specification.new do |spec|
+  spec.name          = "ministry_of_state"
+  spec.version       = MinistryOfState::VERSION
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Hemant Kumar"]
-  s.date = %q{2011-10-26}
-  s.description = %q{A ActiveRecord plugin for working with state machines}
-  s.email = %q{gethemant@gmail.com}
-  s.extra_rdoc_files = [
-    "LICENSE.txt",
-    "README.rdoc"
-  ]
-  s.files = [
-    "Gemfile",
-    "LICENSE.txt",
-    "README.rdoc",
-    "Rakefile",
-    "VERSION",
-    "lib/ministry_of_state.rb",
-    "lib/ministry_of_state/ministry_of_state.rb",
-    "lib/ministry_of_state/railtie.rb",
-    "ministry_of_state.gemspec",
-    "test/article.rb",
-    "test/blog.rb",
-    "test/cargo.rb",
-    "test/helper.rb",
-    "test/post.rb",
-    "test/student.rb",
-    "test/test_ministry_of_state.rb",
-    "test/user.rb"
-  ]
-  s.homepage = %q{http://github.com/gnufied/ministry_of_state}
-  s.licenses = ["MIT"]
-  s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.7}
-  s.summary = %q{Handling state machines}
-  s.test_files = [
-    "test/article.rb",
-    "test/blog.rb",
-    "test/cargo.rb",
-    "test/helper.rb",
-    "test/post.rb",
-    "test/student.rb",
-    "test/test_ministry_of_state.rb",
-    "test/user.rb"
-  ]
+  spec.authors       = ["Hemant Kumar"]
+  spec.email         = ["gethemant@gmail.com"]
+  spec.description   = %q{A ActiveRecord plugin for working with state machines}
+  spec.summary       = %q{Handling state machines}
+  spec.homepage      = %q{http://github.com/gnufied/ministry_of_state}
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
+  spec.license       = "MIT"
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rails>, [">= 3.0.3"])
-      s.add_development_dependency(%q<sqlite3>, [">= 0"])
-      s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_development_dependency(%q<rdoc>, [">= 2.4.2"])
-    else
-      s.add_dependency(%q<rails>, [">= 3.0.3"])
-      s.add_dependency(%q<sqlite3>, [">= 0"])
-      s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<bundler>, [">= 1.0.0"])
-      s.add_dependency(%q<rdoc>, [">= 2.4.2"])
-    end
-  else
-    s.add_dependency(%q<rails>, [">= 3.0.3"])
-    s.add_dependency(%q<sqlite3>, [">= 0"])
-    s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<bundler>, [">= 1.0.0"])
-    s.add_dependency(%q<rdoc>, [">= 2.4.2"])
-  end
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.has_rdoc      = true
+  spec.extra_rdoc_files = ["LICENSE.txt",
+                           "README.rdoc"]
+  
+  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "rake"
+  spec.add_dependency             "rails", "~> 3.2.13"
+  spec.add_development_dependency "sqlite3", "~> 1.3.7"
+  spec.add_development_dependency "shoulda", "~> 3.5.0"
+  spec.add_development_dependency "mocha", "~> 0.14.0"
+  spec.add_development_dependency "debugger", "~> 1.6.0"
 end
-

--- a/test/test_ministry_of_state.rb
+++ b/test/test_ministry_of_state.rb
@@ -10,7 +10,7 @@ ActiveRecord::Base.configurations = {
   'db1' => {
     :adapter  => 'sqlite3',
     :encoding => 'utf8',
-    :database => 'ministry_of_state_test',
+    :database => ':memory:',
   }
 }
 


### PR DESCRIPTION
- update gemspec to a modern version
  by removing depenency on older rubygems specs
  and all gems dependencies have versions
- add gem_tasks to Rakefile
- add file to track version
- add MIT License header to LICENSE
- update gitignore
- add installation instructions to README
