### PR TITLE
can specify from transition as :any

### DIFF
--- a/lib/ministry_of_state/ministry_of_state.rb
+++ b/lib/ministry_of_state/ministry_of_state.rb
@@ -83,6 +83,10 @@ module MinistryOfState
     end
 
     def transitions(opts = {})
+      if opts[:from] == :any
+        opts[:from] = self.states.keys
+      end
+
       if opts[:from].blank? || opts[:to].blank?
         raise TransitionNotAllowed.new("You need to specify from and to states")
       end

--- a/test/blog.rb
+++ b/test/blog.rb
@@ -8,9 +8,14 @@ class Blog < ActiveRecord::Base
     add_initial_state 'pending'
 
     add_state :approved, :enter => :test_method
+    add_state :cancelled
 
     add_event :approve do
       transitions :from => 'pending', :to => 'approved'
+    end
+
+    add_event(:cancel) do
+      transitions from: :any, to: 'cancelled'
     end
   end
 

--- a/test/test_ministry_of_state.rb
+++ b/test/test_ministry_of_state.rb
@@ -147,6 +147,26 @@ class TestMinistryOfState < ActiveSupport::TestCase
     end
   end
 
+  context "can specify from transition as any" do
+    should "cancel a pending blog" do
+      @pending_blog = Blog.create(status: 'pending', text: "some text")
+      assert @pending_blog.cancel!
+      assert @pending_blog.errors.blank?
+    end
+
+    should "cancel a approved blog" do
+      @approved_blog = Blog.create(status: 'approved', text: "some text")
+      assert @approved_blog.cancel!
+      assert @approved_blog.errors.blank?
+    end
+
+    should "cancel an already cancelled blog" do
+      @cancelled_blog = Blog.create(status: 'cancelled', text: "some text")
+      assert @cancelled_blog.cancel!
+      assert @cancelled_blog.errors.blank?
+    end
+  end
+
   context "calling enter and exit callbacks for normal events" do
     setup do
       @post = Post.create(:title => "Hello", :content => "Good world")


### PR DESCRIPTION
this works because when we call add_state
we build a table of known states
